### PR TITLE
Add Passport Photo Studio to apps index; portable index generation

### DIFF
--- a/generate_index.sh
+++ b/generate_index.sh
@@ -97,8 +97,23 @@ sed 's|.*<a.*>\(.*\)</a.*|\1|' "$temp_file_apps" | paste -d'|' - "$temp_file_app
 mv "$sort_temp_file" "$temp_file_apps"
 
 
-# Replace content between <ol id="pages"> and </ol> tags for General Apps
-sed -i${sed_backup:+' '} -e '/<ol id="pages">/,/<\/ol>/{/<ol id="pages">/!{/<\/ol>/!d}}' -e "/<ol id=\"pages\">/r $temp_file_apps" index.html
+# Replace content between <ol id="pages"> and </ol> tags (awk: portable macOS/Linux)
+awk -v listfile="$temp_file_apps" '
+    /<ol id="pages">/ {
+        print
+        while ((getline line < listfile) > 0) print line
+        close(listfile)
+        skip = 1
+        next
+    }
+    skip && /<\/ol>/ {
+        print
+        skip = 0
+        next
+    }
+    skip { next }
+    { print }
+' index.html > index.html.tmp && mv index.html.tmp index.html
 
 echo "Generated $(wc -l < "$temp_file_apps") Apps"
 

--- a/index.html
+++ b/index.html
@@ -95,6 +95,7 @@
                         <li><a href="https://editor.sanjaysingh.net" target="_blank" rel="noopener">Offline Code Editor</a></li>
                         <li><a href="/sheet" target="_blank" rel="noopener">Offline Spreadsheet</a></li>
                         <li><a href="https://pdftools.sanjaysingh.net" target="_blank" rel="noopener">PDF Tools</a></li>
+                        <li><a href="https://passportphoto.meilt.com" target="_blank" rel="noopener">Passport Photo Studio</a></li>
                         <li><a href="https://qrcode.sanjaysingh.net" target="_blank" rel="noopener">QR Code Generator</a></li>
                         <li><a href="https://splitexp.sanjaysingh.net" target="_blank" rel="noopener">Split Expenses</a></li>
                         <li><a href="/tickingstopwatch" target="_blank" rel="noopener">Ticking Stopwatch</a></li>

--- a/other-apps-repo.txt
+++ b/other-apps-repo.txt
@@ -8,3 +8,4 @@ https://github.com/sanjaysingh/splitexp/blob/main/index.html
 https://github.com/sanjaysingh/timedashboard/blob/main/index.html
 https://github.com/sanjaysingh/gql-playground/blob/main/index.html
 https://github.com/sanjaysingh/pdf-tools/blob/main/index.html
+https://github.com/sanjaysingh/passportphoto/blob/main/index.html


### PR DESCRIPTION
## Summary
- Register [passportphoto](https://github.com/sanjaysingh/passportphoto) in `other-apps-repo.txt` so it appears on the apps home page (title and URL resolved via the existing script, including CNAME when present).
- Replace the macOS-incompatible `sed` range rewrite in `generate_index.sh` with portable `awk` so local runs match CI.
- Regenerate `index.html`.

## Test Plan
- [x] `./generate_index.sh` completes without errors locally
- [ ] GitHub Actions checks pass on this PR

Made with [Cursor](https://cursor.com)